### PR TITLE
Clarified attribute mapping docs.

### DIFF
--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -379,12 +379,9 @@ SAML_ATTRIBUTE_MAPPING option in your settings.py::
 where the keys of this dictionary are SAML user attributes and the values
 are Django User attributes.
 
-If you are using Django user profile objects to store extra attributes
-about your user you can add those attributes to the SAML_ATTRIBUTE_MAPPING
-dictionary. For each (key, value) pair, djangosaml2 will try to store the
-attribute in the User model if there is a matching field in that model.
-Otherwise it will try to do the same with your profile custom model. For
-multi-valued attributes only the first value is assigned to the destination field.
+For each (key, value) pair, djangosaml2 will try to store the attribute (key) in your
+configured `User` model if the matching fields exists on that model. For multi-valued
+attributes only the first value is assigned to the destination field.
 
 Alternatively, custom processing of attributes can be achieved by setting the
 value(s) in the SAML_ATTRIBUTE_MAPPING, to name(s) of method(s) defined on a


### PR DESCRIPTION
PR related to the issue #334.

The current documentation makes it seem that attributes will be mapped to "profile" object if configured. In Django parlance, "profile" typically refers the model related to the `User` via `OneToOneField`.

Excerpt from [Django docs](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#extending-the-existing-user-model):

> If you wish to store information related to User, you can use a [OneToOneField](https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.OneToOneField) to a model containing the fields for additional information. This one-to-one model is often called a **profile** model, as it might store non-auth related information about a site user. For example you might create an Employee model:

This is not the case, and this changes makes it clear that attributes will be mapped to the `User` model only, including custom `User` models if configured.