### PR TITLE
Add support for Django 5.2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,17 @@ jobs:
           django-version: "4.2"
         - python-version: "3.13"
           django-version: "5.1"
-
+        exclude:
+          # Python 3.9 is incompatible with Django v5+
+          - django-version: 5.0
+            python-version: 3.9
+          - django-version: 5.1
+            python-version: 3.9
+          - django-version: 5.2
+            python-version: 3.9
+          # Django 4.2 is incompatible with Python 3.13+
+          - django-version: 4.2
+            python-version: 3.13
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0", "5.1"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.0", "5.1", "5.2"]
         include:
         - python-version: "3.9"
           django-version: "4.2"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}
+    py{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1,5.2}
 
 [testenv]
 commands =
@@ -11,6 +11,7 @@ deps =
     django4.2: django~=4.2
     django5.0: django~=5.0
     django5.1: django~=5.1
+    django5.2: django~=5.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     .
 


### PR DESCRIPTION
- [x] Update tox.ini Add django 5.2 to tox.ini
- [x] Updated classifiers in setup.py
- [x] Update GH actions matrix, add `exclude` section for unsupported versions of Python by Django version (e.g. Django 5.2 does not support Python 3.9)